### PR TITLE
Add script to create _custom.scss file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ assets:
 	$(DEVDOCKER) /node_modules/webpack/bin/webpack.js --env.prod
 
 assets-dev:
+	touch aleph/static/style/_custom.scss;
 	$(DEVDOCKER) /node_modules/webpack/bin/webpack.js --env.dev -w
 
 rebuild:


### PR DESCRIPTION
#### What this PR does?
This PR adds a script in the makefile to create a _custom.scss file on running the `make assets-dev` when setting up aleph.
#### Background context
Initially on running the command `make assets-dev` there was an  import error when building js modules since `/aleph/aleph/static/style/aleph.scss` imports from the file in question.
#### Alternative
This file can also be created manually in `/aleph/aleph/static/style/` folder before running the `make assets-dev` command
